### PR TITLE
Remove spaces to avoid error sourcing file

### DIFF
--- a/cyclecloud/.envrc-template
+++ b/cyclecloud/.envrc-template
@@ -21,9 +21,9 @@ export TF_VAR_cyclecloud_subnet="subnet-name"
 export TF_VAR_cyclecloud_subnet_address_prefix="10.50.0.0/24"
 export TF_VAR_cyclecloud_admin_name="cyclecloud-admin-username"
 # Name of an existing virtual network to peer to and use as virtual network gateway
-export TF_VAR_existing_vnet = "existing-vnet-name"
+export TF_VAR_existing_vnet="existing-vnet-name"
 # Name of resource group containing existing virtual network
-export TF_vAR_existing_vnet_rg = "existing-vnet-rg-name"
+export TF_vAR_existing_vnet_rg="existing-vnet-rg-name"
 
 # Must be at least 8 characters, and have three of the following: 1 uppercase, 1 lowercase, 1 number, 1 special character
 export TF_VAR_cyclecloud_admin_password="ccAdmin!23"


### PR DESCRIPTION
export VAR = VALUE will generate error when sourcing the file. This fix is just to remove the space VAR=VALUE.